### PR TITLE
feat: add standalone HTML UI

### DIFF
--- a/client/ui.lua
+++ b/client/ui.lua
@@ -1,0 +1,10 @@
+RegisterCommand('appearanceui', function()
+    SetNuiFocus(true, true)
+    SendNUIMessage({ action = 'open' })
+end)
+
+RegisterNUICallback('close', function(_, cb)
+    SetNuiFocus(false, false)
+    SendNUIMessage({ action = 'close' })
+    if cb then cb('ok') end
+end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,6 +5,7 @@ lua54 'yes'
 
 description 'rsg-appearance'
 version '2.4.8'
+ui_page 'html/index.html'
 
 shared_scripts {
     '@ox_lib/init.lua',
@@ -26,10 +27,12 @@ files {
     'data/overlays.lua',
     'data/clothing.lua',
     'data/hairs_list.lua',
-    'data/clothes_list.lua'
+    'data/clothes_list.lua',
+    'html/index.html',
+    'html/script.js',
+    'html/style.css'
 }
 
 dependencies {
-    'rsg-core',
     'ox_lib'
 }

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="style.css" />
+  <title>RSG Appearance</title>
+</head>
+<body>
+  <div id="container">
+    <h1>RSG Appearance</h1>
+    <button id="close">Close</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/html/script.js
+++ b/html/script.js
@@ -1,0 +1,18 @@
+window.addEventListener('message', (event) => {
+  if (event.data.action === 'open') {
+    document.body.style.display = 'flex';
+  }
+  if (event.data.action === 'close') {
+    document.body.style.display = 'none';
+  }
+});
+
+document.getElementById('close').addEventListener('click', () => {
+  fetch('https://rsg-appearance/close', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({})
+  });
+});
+
+document.body.style.display = 'none';

--- a/html/style.css
+++ b/html/style.css
@@ -1,0 +1,17 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+#container {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add simple HTML interface for appearance resource
- enable client command to toggle new UI
- update manifest with NUI page and assets while dropping framework dependency

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc76a4540832aaa808c672233bc46